### PR TITLE
hotfix/CP-2518-Remote notification support.

### DIFF
--- a/ios/Classes/CleverPushPlugin.m
+++ b/ios/Classes/CleverPushPlugin.m
@@ -46,7 +46,7 @@
     else if ([@"CleverPush#getNotifications" isEqualToString:call.method])
         [self getNotifications:call withResult:result];
     else if ([@"CleverPush#getNotificationsWithApi" isEqualToString:call.method])
-        [self getRemoteNotifications:call withResult:result];    
+        [self getNotificationsWithApi:call withResult:result];
     else if ([@"CleverPush#getSubscriptionTopics" isEqualToString:call.method])
         [self getSubscriptionTopics:call withResult:result];
     else if ([@"CleverPush#setSubscriptionTopics" isEqualToString:call.method])


### PR DESCRIPTION
file changes:
`CleverPushPlugin.m`
access the method by correct name as previously method name was "`getRemoteNotification`" but after some alterations we have changed the name as "`getNotificationsWithApi`" so the plugin bridge was using old method instead of "`getNotificationsWithApi`".