### PR TITLE
hotfix/CP-7193-ios-crashes-on-app-launch-following-clever-push-sdk-integration-on-ios

### DIFF
--- a/ios/Classes/CleverPushPlugin.m
+++ b/ios/Classes/CleverPushPlugin.m
@@ -226,10 +226,10 @@
 - (void)getNotificationsWithApi:(FlutterMethodCall *)call withResult:(FlutterResult)result {
     NSMutableArray *remoteNotifications = [NSMutableArray new];
     [CleverPush getNotifications:call.arguments[@"combineWithApi"] callback:^(NSArray* Notifications) {
-        [Notifications enumerateObjectsWithOptions: NSEnumerationConcurrent usingBlock: ^(id obj, NSUInteger idx, BOOL *stop) {
-            NSDictionary *dict = [self dictionaryWithPropertiesOfObject: obj];
+        for (CPNotification *notification in Notifications) {
+            NSDictionary *dict = [self dictionaryWithPropertiesOfObject:notification];
             [remoteNotifications addObject:dict];
-        }];
+        }
         result(remoteNotifications);
     }];
 }


### PR DESCRIPTION
Resolved crashed issue in the `getNotificationsWithApi` method in iOS.