### PR TITLE
hotfix/CP-7358-ios-flutter-sdk-crash-in-get-available-topics

### DIFF
--- a/ios/Classes/CleverPushPlugin.m
+++ b/ios/Classes/CleverPushPlugin.m
@@ -246,12 +246,12 @@
 }
 
 - (void)getAvailableTopics:(FlutterMethodCall *)call withResult:(FlutterResult)result {
+    NSMutableArray *availableTopics = [NSMutableArray new];
     [CleverPush getAvailableTopics:^(NSArray* channelTopics_) {
-        NSMutableArray *availableTopics = [NSMutableArray new];
-        [channelTopics_ enumerateObjectsWithOptions: NSEnumerationConcurrent usingBlock: ^(id obj, NSUInteger idx, BOOL *stop) {
-            NSDictionary *dict = [self dictionaryWithPropertiesOfObject: obj];
+        for (CPChannelTopic *topic in channelTopics_) {
+            NSDictionary *dict = [self dictionaryWithPropertiesOfObject:topic];
             [availableTopics addObject:dict];
-        }];
+        }
         result(availableTopics);
     }];
 }


### PR DESCRIPTION
Resolved crashed issue in the `getAvailableTopics` method in iOS.