### PR TITLE
hotfix/CP-7484-flutter-ios-getting-crash-in-get-available-tags-sometimes

### DIFF
--- a/ios/Classes/CleverPushPlugin.m
+++ b/ios/Classes/CleverPushPlugin.m
@@ -305,12 +305,12 @@
 }
 
 - (void)getAvailableTags:(FlutterMethodCall *)call withResult:(FlutterResult)result {
+    NSMutableArray *availableTags = [NSMutableArray new];
     [CleverPush getAvailableTags:^(NSArray* channelTags_) {
-        NSMutableArray *availableTags = [NSMutableArray new];
-        [channelTags_ enumerateObjectsWithOptions: NSEnumerationConcurrent usingBlock: ^(id obj, NSUInteger idx, BOOL *stop) {
-            NSDictionary *dict = [self dictionaryWithPropertiesOfObject: obj];
+        for (CPChannelTag *tag in channelTags_) {
+            NSDictionary *dict = [self dictionaryWithPropertiesOfObject:tag];
             [availableTags addObject:dict];
-        }];
+        }
         result(availableTags);
     }];
 }


### PR DESCRIPTION
Optimised `getAvailableTags` method for preventing a crash in iOS.