### PR TITLE
hotfix/CP-7359-ios-flutter-notification-opened-handler-not-working-sometimes

### DIFF
--- a/ios/Classes/CleverPushPlugin.m
+++ b/ios/Classes/CleverPushPlugin.m
@@ -477,7 +477,11 @@
             if ([object isKindOfClass:[NSArray class]]) {
                 NSMutableArray *subObj = [NSMutableArray array];
                 for (id o in object) {
-                    [subObj addObject:[self dictionaryWithPropertiesOfObject:o]];
+                    if ([o isKindOfClass:[NSDictionary class]]) {
+                        [subObj addObject:o];
+                    } else {
+                        [subObj addObject:[self dictionaryWithPropertiesOfObject:o]];
+                    }
                 }
                 dict[key] = subObj;
             } else if (


### PR DESCRIPTION
Optimized `dictionaryWithPropertiesOfObject'` method while the object type is an array in iOS.