### PR TITLE
hotfix/CP-9121-flutter-sdk-accessing-push-notification-data-is-blocked-on-ios

### DIFF
--- a/ios/Classes/CleverPushPlugin.m
+++ b/ios/Classes/CleverPushPlugin.m
@@ -458,7 +458,9 @@
 - (void)handleSubscribed:(NSString *)result {
     NSMutableDictionary *resultDict = [NSMutableDictionary new];
     resultDict[@"subscriptionId"] = result;
-    [self.channel invokeMethod:@"CleverPush#handleSubscribed" arguments:resultDict];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [self.channel invokeMethod:@"CleverPush#handleSubscribed" arguments:resultDict];
+    });
 }
 
 - (void)handleNotificationReceived:(CPNotificationReceivedResult *)result {


### PR DESCRIPTION
Optimised `handleSubscribed` method to prevent a crash or warning.