### PR TITLE
hotfix/CP-9314-bug-android-builds-fail-for-latest-flutter-version-3-29

### DIFF
--- a/android/src/main/java/com/cleverpush/flutter/CleverPushPlugin.java
+++ b/android/src/main/java/com/cleverpush/flutter/CleverPushPlugin.java
@@ -30,7 +30,6 @@ import com.cleverpush.listener.NotificationsCallbackListener;
 import com.cleverpush.listener.SubscribedCallbackListener;
 import com.cleverpush.listener.SubscribedListener;
 import com.cleverpush.listener.TopicsDialogListener;
-import com.cleverpush.responsehandlers.SetSubscriptionAttributeResponseHandler;
 import com.cleverpush.util.ColorUtils;
 
 import org.json.JSONArray;
@@ -51,21 +50,14 @@ import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
-import io.flutter.plugin.common.PluginRegistry.Registrar;
 import io.flutter.plugin.platform.PlatformViewRegistry;
 
-public class CleverPushPlugin extends FlutterRegistrarResponder implements MethodCallHandler, NotificationOpenedListener, SubscribedListener, FlutterPlugin, ActivityAware {
+public class CleverPushPlugin extends FlutterMessengerResponder implements MethodCallHandler, NotificationOpenedListener, SubscribedListener, FlutterPlugin, ActivityAware {
     private NotificationOpenedResult coldStartNotificationResult;
     private boolean hasSetNotificationOpenedHandler = false;
     private boolean showNotificationsInForeground = true;
     private Context context;
     private Activity activity;
-
-    @SuppressWarnings("deprecation")
-    public static void registerWith(Registrar registrar) {
-        final CleverPushPlugin plugin = new CleverPushPlugin();
-        plugin.onAttachedToEngine(registrar.context(), registrar.messenger());
-    }
 
     @Override
     public void onAttachedToEngine(@NonNull final FlutterPluginBinding binding) {

--- a/android/src/main/java/com/cleverpush/flutter/FlutterMessengerResponder.java
+++ b/android/src/main/java/com/cleverpush/flutter/FlutterMessengerResponder.java
@@ -1,17 +1,14 @@
 package com.cleverpush.flutter;
 
-import android.app.Activity;
 import android.os.Handler;
 import android.os.Looper;
 
 import java.util.HashMap;
 
 import io.flutter.plugin.common.MethodChannel;
-import io.flutter.plugin.common.PluginRegistry;
 
-abstract class FlutterRegistrarResponder {
+abstract class FlutterMessengerResponder {
     MethodChannel channel;
-    PluginRegistry.Registrar flutterRegistrar;
 
     void replySuccess(final MethodChannel.Result reply, final Object response) {
         runOnMainThread(new Runnable() {


### PR DESCRIPTION
1. Remove references to the now deprecated v1 Android embedding.
2. rename FlutterRegistrarResponder class