### PR TITLE
hotfix/cp-9584-issue-with-cleverpush_flutter-on-ios-the-init-function-gets

### DIFF
--- a/ios/Classes/CPChatViewFlutter.m
+++ b/ios/Classes/CPChatViewFlutter.m
@@ -37,7 +37,9 @@
     _chatView = [[CPChatView alloc] initWithFrame:frame urlOpenedCallback:^(NSURL *url) {
       NSMutableDictionary *resultDict = [NSMutableDictionary new];
       resultDict[@"url"] = url.absoluteString;
-      [[[CleverPushPlugin sharedInstance] channel] invokeMethod:@"CleverPush#handleChatUrlOpened" arguments:resultDict];
+      dispatch_async(dispatch_get_main_queue(), ^{
+          [[[CleverPushPlugin sharedInstance] channel] invokeMethod:@"CleverPush#handleChatUrlOpened" arguments:resultDict];
+      });
     } subscribeCallback:^() {
         
     }];

--- a/ios/Classes/CleverPushPlugin.m
+++ b/ios/Classes/CleverPushPlugin.m
@@ -435,7 +435,9 @@
     [CleverPush setLogListener:^(NSString* message) {
         NSMutableDictionary *resultDict = [NSMutableDictionary new];
         resultDict[@"message"] = message;
-        [self.channel invokeMethod:@"CleverPush#handleLog" arguments:resultDict];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self.channel invokeMethod:@"CleverPush#handleLog" arguments:resultDict];
+        });
     }];
     result(nil);
 }
@@ -495,25 +497,33 @@
 - (void)handleNotificationReceived:(CPNotificationReceivedResult *)result {
     NSMutableDictionary *resultDict = [NSMutableDictionary new];
     resultDict[@"notification"] = [self dictionaryWithPropertiesOfObject:result.notification];
-    [self.channel invokeMethod:@"CleverPush#handleNotificationReceived" arguments:resultDict];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [self.channel invokeMethod:@"CleverPush#handleNotificationReceived" arguments:resultDict];
+    });
 }
 
 - (void)handleNotificationOpened:(CPNotificationOpenedResult *)result {
     NSMutableDictionary *resultDict = [NSMutableDictionary new];
     resultDict[@"notification"] = [self dictionaryWithPropertiesOfObject:result.notification];
-    [self.channel invokeMethod:@"CleverPush#handleNotificationOpened" arguments:resultDict];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [self.channel invokeMethod:@"CleverPush#handleNotificationOpened" arguments:resultDict];
+    });
 }
 
 - (void)handleAppBannerShown:(CPAppBanner *)appBanner {
     NSMutableDictionary *resultDict = [NSMutableDictionary new];
     resultDict[@"appBanner"] = [self dictionaryWithPropertiesOfObject:appBanner];
-    [self.channel invokeMethod:@"CleverPush#handleAppBannerShown" arguments:resultDict];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [self.channel invokeMethod:@"CleverPush#handleAppBannerShown" arguments:resultDict];
+    });
 }
 
 - (void)handleAppBannerOpened:(CPAppBannerAction *)action {
     NSMutableDictionary *resultDict = [NSMutableDictionary new];
     resultDict[@"action"] = [self dictionaryWithPropertiesOfObject:action];
-    [self.channel invokeMethod:@"CleverPush#handleAppBannerOpened" arguments:resultDict];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [self.channel invokeMethod:@"CleverPush#handleAppBannerOpened" arguments:resultDict];
+    });
 }
 
 - (void)handleInitializationResult:(NSString *)failureMessage success:(BOOL)success {


### PR DESCRIPTION
Optimized `init` function to prevent a crash or warning.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed a crash in the CleverPush Flutter iOS plugin by ensuring all method channel calls run on the main thread. This prevents warnings and improves app stability.

<!-- End of auto-generated description by cubic. -->

