### PR TITLE
hotfix/cp-8499-flutter-notification-opened-handler-not-called-android

### DIFF
--- a/android/src/main/java/com/cleverpush/flutter/CleverPushPlugin.java
+++ b/android/src/main/java/com/cleverpush/flutter/CleverPushPlugin.java
@@ -80,10 +80,6 @@ public class CleverPushPlugin extends FlutterMessengerResponder implements Metho
 
     @Override
     public void onDetachedFromEngine(@NonNull FlutterPluginBinding binding) {
-        CleverPush.getInstance(binding.getApplicationContext()).removeNotificationReceivedListener();
-        CleverPush.getInstance(binding.getApplicationContext()).removeNotificationOpenedListener();
-        CleverPush.getInstance(binding.getApplicationContext()).removeSubscribedListener();
-        context = null;
     }
 
     @Override


### PR DESCRIPTION
Notification Received/Opened, Subscribe Handler not being called with workManager
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed an issue where notification received, opened, and subscribed handlers were not called on Android when using WorkManager. Removed code that was unregistering these listeners during plugin detachment.

<!-- End of auto-generated description by cubic. -->

