### PR TITLE
feature/cp-9638-flutter-sdk-update-cleverpush-flutter-sdk-to-api-level-35

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.0'
+        classpath 'com.android.tools.build:gradle:8.1.4'
     }
 }
 
@@ -26,7 +26,7 @@ apply plugin: 'com.android.library'
 android {
     namespace "com.cleverpush.flutter"
 
-    compileSdkVersion 28
+    compileSdkVersion 34
 
     defaultConfig {
         minSdkVersion 19

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Oct 17 14:56:12 PDT 2019
+#Wed Jul 23 17:14:47 IST 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -17,7 +17,7 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 android {
     namespace "com.cleverpush.example"
 
-    compileSdkVersion 33
+    compileSdkVersion 34
 
 	compileOptions {
 		targetCompatibility = "8"
@@ -29,7 +29,7 @@ android {
 
     defaultConfig {
         applicationId "com.cleverpush.example"
-        minSdkVersion 19
+        minSdkVersion 21
         targetSdkVersion 33
         versionCode 1
         versionName "1.0"

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.7.0'
     repositories {
         google()
         jcenter()
@@ -7,7 +7,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        classpath 'com.android.tools.build:gradle:8.1.4'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.google.gms:google-services:4.3.3'
     }

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Update CleverPush Flutter SDK to API Level 35
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Updated CleverPush Flutter SDK and example app to use Android API Level 34 and the latest Gradle and Kotlin versions for better compatibility with recent Android releases.

- **Dependencies**
  - Upgraded Gradle to 8.5 and Android Gradle Plugin to 8.1.4.
  - Updated Kotlin to 1.7.0.
  - Increased minSdkVersion in the example app to 21.

<!-- End of auto-generated description by cubic. -->

