### PR TITLE
feature/cp-9509-flutter-implement-setread-in-notification-class

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -38,7 +38,7 @@ android {
 }
 
 dependencies {
-	api 'com.cleverpush:cleverpush:1.35.3'
+	api 'com.cleverpush:cleverpush:1.35.7'
 }
 
 class DefaultManifestPlaceHolders {

--- a/android/src/main/java/com/cleverpush/flutter/CleverPushPlugin.java
+++ b/android/src/main/java/com/cleverpush/flutter/CleverPushPlugin.java
@@ -192,6 +192,10 @@ public class CleverPushPlugin extends FlutterMessengerResponder implements Metho
             this.showAppBanner(call, result);
         } else if (call.method.contentEquals("CleverPush#setMaximumNotificationCount")) {
             this.setMaximumNotificationCount(call, result);
+        }  else if (call.method.contentEquals("CleverPush#setNotificationRead")) {
+            this.setNotificationRead(call, result);
+        }  else if (call.method.contentEquals("CleverPush#getNotificationRead")) {
+            this.getNotificationRead(call, result);
         } else {
             replyNotImplemented(result);
         }
@@ -754,5 +758,18 @@ public class CleverPushPlugin extends FlutterMessengerResponder implements Metho
             CleverPush.getInstance(context).showAppBanner(id);
             replySuccess(result, null);
         }
+    }
+
+    private void setNotificationRead(MethodCall call, final Result result) {
+        Boolean read = call.argument("read");
+        String notificationId = call.argument("notificationId");
+        CleverPush.getInstance(context).setNotificationRead(read, notificationId);
+        replySuccess(result, null);
+    }
+
+    private void getNotificationRead(MethodCall call, final Result result) {
+        String notificationId = call.argument("notificationId");
+        Boolean notificationRead = CleverPush.getInstance(context).getNotificationRead(notificationId);
+        replySuccess(result, notificationRead);
     }
 }

--- a/android/src/main/java/com/cleverpush/flutter/CleverPushSerializer.java
+++ b/android/src/main/java/com/cleverpush/flutter/CleverPushSerializer.java
@@ -26,6 +26,7 @@ class CleverPushSerializer {
         hash.put("createdAt", payload.getCreatedAt());
         hash.put("chatNotification",payload.isChatNotification());
         hash.put("appBanner", payload.getAppBanner());
+        hash.put("read", payload.getRead());
 
         ArrayList<HashMap> buttons = new ArrayList<>();
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,10 +1,10 @@
 PODS:
-  - CleverPush (1.34.7):
-    - CleverPush/CleverPush (= 1.34.7)
-  - CleverPush/CleverPush (1.34.7)
-  - CleverPush/CleverPushExtension (1.34.7)
+  - CleverPush (1.34.23):
+    - CleverPush/CleverPush (= 1.34.23)
+  - CleverPush/CleverPush (1.34.23)
+  - CleverPush/CleverPushExtension (1.34.23)
   - cleverpush_flutter (1.24.22):
-    - CleverPush (= 1.34.7)
+    - CleverPush (= 1.34.23)
     - Flutter
   - Flutter (1.0.0)
 
@@ -24,8 +24,8 @@ EXTERNAL SOURCES:
     :path: Flutter
 
 SPEC CHECKSUMS:
-  CleverPush: 09f49eba224cff80ccd9e5e6162465347c11a354
-  cleverpush_flutter: be7cd66abe5d5995514293e363d71ed46a8bdd26
+  CleverPush: 1e823605b314ade1070ca9354f88d9299ef3f3b3
+  cleverpush_flutter: 4b0b8963fafdea7abfbc338e2f44b9870aa1a6c4
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
 
 PODFILE CHECKSUM: 73fed6ca4417c06a8c5d57f12c621d3468f0e3b5

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,10 +1,10 @@
 PODS:
-  - CleverPush (1.34.23):
-    - CleverPush/CleverPush (= 1.34.23)
-  - CleverPush/CleverPush (1.34.23)
-  - CleverPush/CleverPushExtension (1.34.23)
+  - CleverPush (1.34.24):
+    - CleverPush/CleverPush (= 1.34.24)
+  - CleverPush/CleverPush (1.34.24)
+  - CleverPush/CleverPushExtension (1.34.24)
   - cleverpush_flutter (1.24.22):
-    - CleverPush (= 1.34.23)
+    - CleverPush (= 1.34.24)
     - Flutter
   - Flutter (1.0.0)
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -35,6 +35,10 @@ class _MyAppState extends State<MyApp> {
 
     CleverPush.shared
         .setNotificationOpenedHandler((CPNotificationOpenedResult result) {
+      //Mark Notification as Read
+      /*if (result.notification != null) {
+        result.notification!.setRead(true);
+      }*/
       this.setState(() {
         _debugLabelString =
             "Notification opened: \n${result.notification!.jsonRepresentation().replaceAll("\\n", "\n")}";

--- a/ios/Classes/CleverPushPlugin.m
+++ b/ios/Classes/CleverPushPlugin.m
@@ -563,13 +563,13 @@
     NSString *notificationId = call.arguments[@"notificationId"];
     BOOL read = [call.arguments[@"read"] boolValue];
 
-    [[CleverPush sharedInstance] setNotificationRead:notificationId read:read];
+    [CleverPush setNotificationRead:notificationId read:read];
     result(nil);
 }
 
 - (void)getNotificationRead:(FlutterMethodCall *)call withResult:(FlutterResult)result {
     NSString *notificationId = call.arguments[@"notificationId"];
-    BOOL notificationRead = [[CleverPush sharedInstance] getNotificationRead:notificationId];
+    BOOL notificationRead = [CleverPush getNotificationRead:notificationId];
     result([NSNumber numberWithBool:notificationRead]);
 }
 

--- a/ios/Classes/CleverPushPlugin.m
+++ b/ios/Classes/CleverPushPlugin.m
@@ -137,6 +137,10 @@
         [self showAppBanner:call withResult:result];
     else if ([@"CleverPush#setMaximumNotificationCount" isEqualToString:call.method])
         [self setMaximumNotificationCount:call withResult:result];
+    else if ([@"CleverPush#setNotificationRead" isEqualToString:call.method])
+        [self setNotificationRead:call withResult:result];
+    else if ([@"CleverPush#getNotificationRead" isEqualToString:call.method])
+        [self getNotificationRead:call withResult:result];
     else
         result(FlutterMethodNotImplemented);
 }
@@ -553,6 +557,20 @@
         [CleverPush showAppBanner:call.arguments[@"id"]];
         result(nil);
     }
+}
+
+- (void)setNotificationRead:(FlutterMethodCall *)call withResult:(FlutterResult)result {
+    NSString *notificationId = call.arguments[@"notificationId"];
+    BOOL read = [call.arguments[@"read"] boolValue];
+
+    [[CleverPush sharedInstance] setNotificationRead:notificationId read:read];
+    result(nil);
+}
+
+- (void)getNotificationRead:(FlutterMethodCall *)call withResult:(FlutterResult)result {
+    NSString *notificationId = call.arguments[@"notificationId"];
+    BOOL notificationRead = [[CleverPush sharedInstance] getNotificationRead:notificationId];
+    result([NSNumber numberWithBool:notificationRead]);
 }
 
 - (NSDictionary *) dictionaryWithPropertiesOfObject:(id)obj {

--- a/ios/cleverpush_flutter.podspec
+++ b/ios/cleverpush_flutter.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'CleverPush', '1.34.23'
+  s.dependency 'CleverPush', '1.34.24'
   s.static_framework = true
   s.ios.deployment_target = '8.0'
 end

--- a/ios/cleverpush_flutter.podspec
+++ b/ios/cleverpush_flutter.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'CleverPush', '1.34.19'
+  s.dependency 'CleverPush', '1.34.23'
   s.static_framework = true
   s.ios.deployment_target = '8.0'
 end

--- a/lib/src/notification.dart
+++ b/lib/src/notification.dart
@@ -62,6 +62,13 @@ class CPNotification extends JSONStringRepresentable {
 
     if (json.containsKey('read')) {
       this.read = json['read'] as bool?;
+      if (this.id != null) {
+        _channel.invokeMethod("CleverPush#getNotificationRead", {
+          'notificationId': this.id
+        }).then((value) {
+          this.read = value as bool?;
+        });
+      }
     }
   }
 
@@ -73,17 +80,6 @@ class CPNotification extends JSONStringRepresentable {
       });
       this.read = read;
     }
-  }
-
-  Future<bool?> getRead() async {
-    if (this.id != null) {
-      bool? notificationRead = await _channel.invokeMethod("CleverPush#getNotificationRead", {
-        'notificationId': this.id
-      });
-      this.read = notificationRead;
-      return notificationRead;
-    }
-    return this.read;
   }
 
   String jsonRepresentation() => convertToJsonString(this.rawPayload);

--- a/lib/src/notification.dart
+++ b/lib/src/notification.dart
@@ -1,4 +1,5 @@
 import 'json.dart';
+import 'package:flutter/services.dart';
 
 class CPNotification extends JSONStringRepresentable {
   String? id;
@@ -13,6 +14,9 @@ class CPNotification extends JSONStringRepresentable {
   bool? chatNotification;
   bool? silent;
   String? appBanner;
+  bool? read;
+
+  static const MethodChannel _channel = MethodChannel('CleverPush');
 
   CPNotification(Map<String, dynamic> json) {
     this.rawPayload = json;
@@ -55,6 +59,31 @@ class CPNotification extends JSONStringRepresentable {
     if (json.containsKey('appBanner')) {
       this.appBanner = json['appBanner'] as String?;
     }
+
+    if (json.containsKey('read')) {
+      this.read = json['read'] as bool?;
+    }
+  }
+
+  Future<void> setRead(bool read) async {
+    if (this.id != null) {
+      await _channel.invokeMethod("CleverPush#setNotificationRead", {
+        'read': read,
+        'notificationId': this.id
+      });
+      this.read = read;
+    }
+  }
+
+  Future<bool?> getRead() async {
+    if (this.id != null) {
+      bool? notificationRead = await _channel.invokeMethod("CleverPush#getNotificationRead", {
+        'notificationId': this.id
+      });
+      this.read = notificationRead;
+      return notificationRead;
+    }
+    return this.read;
   }
 
   String jsonRepresentation() => convertToJsonString(this.rawPayload);


### PR DESCRIPTION
implement setRead and getRead in Notification class
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added setRead and getRead methods to the Notification class, allowing notifications to be marked as read or unread from Flutter. Updated native Android and iOS code to support these methods.

- **Dependencies**
  - Updated CleverPush SDK versions for Android and iOS.

<!-- End of auto-generated description by cubic. -->

