### PR TITLE
hotfix/cp-10519-flutter-sdk-topics-mapping-issue-parenttopic-vs

### DIFF
--- a/lib/src/topic.dart
+++ b/lib/src/topic.dart
@@ -21,6 +21,8 @@ class CPTopic extends JSONStringRepresentable {
     }
     if (json.containsKey('parentTopicId')) {
       this.parentTopicId = json['parentTopicId'] as String?;
+    } else if (json.containsKey('parentTopic')) {
+      this.parentTopicId = json['parentTopic'] as String?;
     }
     if (json.containsKey('defaultUnchecked')) {
       this.defaultUnchecked = json['defaultUnchecked'] as bool?;


### PR DESCRIPTION
Topics mapping issue (parentTopic(iOS) vs parentTopicId(Android))

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Populate `parentTopicId` from `parentTopic` when `parentTopicId` is absent in `CPTopic` parsing.
> 
> - **Model parsing (`lib/src/topic.dart`)**:
>   - `CPTopic` constructor now falls back to set `parentTopicId` from `parentTopic` if `parentTopicId` is not provided.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 51dd1189feed37ea44592038e964b06e70bec50a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes topic parent mapping in the Flutter SDK to work with both Android and iOS payloads. Addresses CP-10519 by resolving missing parent topics on iOS.

- **Bug Fixes**
  - If parentTopicId is absent, use parentTopic as the source for parentTopicId.

<sup>Written for commit 51dd1189feed37ea44592038e964b06e70bec50a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

