### PR TITLE
feature/cp-10830-flutter-implement-removeallnotifications

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -38,7 +38,7 @@ android {
 }
 
 dependencies {
-    api 'com.cleverpush:cleverpush:1.35.22'
+    api 'com.cleverpush:cleverpush:1.35.23'
 }
 
 class DefaultManifestPlaceHolders {

--- a/android/src/main/java/com/cleverpush/flutter/CleverPushPlugin.java
+++ b/android/src/main/java/com/cleverpush/flutter/CleverPushPlugin.java
@@ -206,6 +206,8 @@ public class CleverPushPlugin extends FlutterMessengerResponder implements Metho
             replySuccess(result, null);
         } else if (call.method.contentEquals("CleverPush#getHandleUniversalLinksInAppForDomains")) { // iOS-only no-op on Android
             replySuccess(result, null);
+        } else if (call.method.contentEquals("CleverPush#removeAllNotifications")) {
+          this.removeAllNotifications(call, result);
         } else {
             replyNotImplemented(result);
         }
@@ -804,16 +806,20 @@ public class CleverPushPlugin extends FlutterMessengerResponder implements Metho
         replySuccess(result, null);
     }
 
-  public void clearNotificationsFromNotificationCenter(MethodCall call, final Result result) {
-      try {
-          NotificationManager notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
-          if (notificationManager != null) {
-              notificationManager.cancelAll();
-          }
-      } catch (Exception e) {
-          e.printStackTrace();
-      }
-      replySuccess(result, null);
-  }
+    public void clearNotificationsFromNotificationCenter(MethodCall call, final Result result) {
+        try {
+            NotificationManager notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+            if (notificationManager != null) {
+                notificationManager.cancelAll();
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        replySuccess(result, null);
+    }
 
+    private void removeAllNotifications(MethodCall call, final Result result) {
+        CleverPush.getInstance(context).removeAllNotifications();
+        replySuccess(result, null);
+    }
 }

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,10 +1,10 @@
 PODS:
-  - CleverPush (1.34.36):
-    - CleverPush/CleverPush (= 1.34.36)
-  - CleverPush/CleverPush (1.34.36)
-  - CleverPush/CleverPushExtension (1.34.36)
+  - CleverPush (1.34.37):
+    - CleverPush/CleverPush (= 1.34.37)
+  - CleverPush/CleverPush (1.34.37)
+  - CleverPush/CleverPushExtension (1.34.37)
   - cleverpush_flutter (1.24.30):
-    - CleverPush (= 1.34.36)
+    - CleverPush (= 1.34.37)
     - Flutter
   - Flutter (1.0.0)
 

--- a/ios/Classes/CleverPushPlugin.m
+++ b/ios/Classes/CleverPushPlugin.m
@@ -152,6 +152,8 @@
         [self setHandleUniversalLinksInAppForDomains:call withResult:result];
     else if ([@"CleverPush#getHandleUniversalLinksInAppForDomains" isEqualToString:call.method])
         [self getHandleUniversalLinksInAppForDomains:call withResult:result];
+    else if ([@"CleverPush#removeAllNotifications" isEqualToString:call.method])
+        [self removeAllNotifications:call withResult:result];
     else
         result(FlutterMethodNotImplemented);
 }
@@ -630,6 +632,11 @@
 - (void)getHandleUniversalLinksInAppForDomains:(FlutterMethodCall *)call withResult:(FlutterResult)result {
     NSArray<NSString *> *domains = [CleverPush getHandleUniversalLinksInAppForDomains];
     result(domains);
+}
+
+- (void)removeAllNotifications:(FlutterMethodCall *)call withResult:(FlutterResult)result {
+    [CleverPush removeAllNotifications];
+    result(nil);
 }
 
 - (NSDictionary *)dictionaryWithPropertiesOfObject:(id)obj {

--- a/ios/cleverpush_flutter.podspec
+++ b/ios/cleverpush_flutter.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'CleverPush', '1.34.36'
+  s.dependency 'CleverPush', '1.34.37'
   s.static_framework = true
   s.ios.deployment_target = '8.0'
 end

--- a/lib/cleverpush_flutter.dart
+++ b/lib/cleverpush_flutter.dart
@@ -301,6 +301,10 @@ class CleverPush {
     return await _channel.invokeMethod("CleverPush#clearNotificationsFromNotificationCenter");
   }
 
+  Future<dynamic> removeAllNotifications() async {
+    return await _channel.invokeMethod("CleverPush#removeAllNotifications");
+  }
+
   Future<void> setHandleUniversalLinksInAppForDomains(List<String>? domains) async {
     await _channel.invokeMethod(
       'CleverPush#setHandleUniversalLinksInAppForDomains',


### PR DESCRIPTION
Implement a new method `removeAllNotifications` to clear all locally stored notifications.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 11b1560e594aa22a4bfcc5bf7effebacc2c87fb5. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds removeAllNotifications to the Flutter plugin to clear all locally stored notifications. Addresses CP-10830.

- **New Features**
  - Exposes CleverPush.removeAllNotifications() in Dart and wires it to native Android/iOS implementations to purge local notifications.

- **Dependencies**
  - Android CleverPush SDK updated to 1.35.23.
  - iOS CleverPush SDK updated to 1.34.37 (podspec and Podfile.lock).

<sup>Written for commit 11b1560e594aa22a4bfcc5bf7effebacc2c87fb5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

