### PR TITLE
hotfix/cp-11278-ios-in-app-message-not-displayed-when-close-button-dark-mode

### DIFF
--- a/ios/Classes/CleverPushPlugin.m
+++ b/ios/Classes/CleverPushPlugin.m
@@ -8,8 +8,10 @@
 @interface CleverPushPlugin ()
 
 @property (strong, nonatomic) CPNotificationOpenedResult *coldStartOpenResult;
-@property (strong, nonatomic) NSDictionary *launchOptions;
+@property (strong, nonatomic) NSDictionary *appLaunchOptions;
+@property (strong, nonatomic) NSMutableArray *pendingNotificationEvents;
 @property (nonatomic) BOOL hasNotificationOpenedHandler;
+@property (nonatomic) BOOL dartInitialized;
 
 @end
 
@@ -40,11 +42,28 @@
     [registrar registerViewFactory:storyFactory withId:@"cleverpush-story-view"];
 
     [registrar addApplicationDelegate:CleverPushPlugin.sharedInstance];
+    
+    NSString *storedChannelId = [[NSUserDefaults standardUserDefaults]
+                                 stringForKey:@"CleverPush_CHANNEL_ID"];
+    if (storedChannelId && storedChannelId.length > 0) {
+        __weak CleverPushPlugin *weakSelf = CleverPushPlugin.sharedInstance;
+        [CleverPush initWithLaunchOptions:nil channelId:storedChannelId
+               handleNotificationReceived:^(CPNotificationReceivedResult *result) {
+            [weakSelf handleNotificationReceived:result];
+        }      handleNotificationOpened:^(CPNotificationOpenedResult *result) {
+            if (!weakSelf.hasNotificationOpenedHandler) {
+                weakSelf.coldStartOpenResult = result;
+            }
+        } handleSubscribed:nil autoRegister:NO handleInitialized:nil];
+    }
 }
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
-    CleverPushPlugin.sharedInstance.launchOptions = launchOptions;
-
+    CleverPushPlugin.sharedInstance.appLaunchOptions = launchOptions;
+    NSDictionary *remoteNotif = launchOptions[UIApplicationLaunchOptionsRemoteNotificationKey];
+    if (remoteNotif && [CleverPush channelId]) {
+        [CleverPush handleSilentNotificationReceived:application UserInfo:remoteNotif completionHandler:nil];
+    }
     return YES;
 }
 
@@ -167,7 +186,12 @@
         autoRegister = [call.arguments[@"autoRegister"] boolValue];
     }
 
-    [CleverPush initWithLaunchOptions:self.launchOptions channelId:channelId
+    if (channelId && channelId.length > 0) {
+        [[NSUserDefaults standardUserDefaults] setObject:channelId forKey:@"CleverPush_CHANNEL_ID"];
+        [[NSUserDefaults standardUserDefaults] synchronize];
+    }
+
+    [CleverPush initWithLaunchOptions:self.appLaunchOptions channelId:channelId
            handleNotificationReceived:^(CPNotificationReceivedResult *result) {
         [self handleNotificationReceived:result];
     } handleNotificationOpened:^(CPNotificationOpenedResult *result) {
@@ -194,6 +218,9 @@
     [CleverPush setAppBannerOpenedCallback:^(CPAppBannerAction *action) {
         [self handleAppBannerOpened:action];
     }];
+    
+    self.dartInitialized = YES;
+    [self deliverPendingNotificationEvents];
 
     result(nil);
 }
@@ -219,7 +246,7 @@
 }
 
 - (void)isSubscribed:(FlutterMethodCall *)call withResult:(FlutterResult)result {
-    bool subscribed = [CleverPush isSubscribed];
+    BOOL subscribed = [CleverPush isSubscribed];
     result([NSNumber numberWithBool:subscribed]);
 }
 
@@ -531,9 +558,40 @@
 - (void)handleNotificationReceived:(CPNotificationReceivedResult *)result {
     NSMutableDictionary *resultDict = [NSMutableDictionary new];
     resultDict[@"notification"] = [self dictionaryWithPropertiesOfObject:result.notification];
+    
+    if (!self.dartInitialized) {
+        if (!self.pendingNotificationEvents) {
+            self.pendingNotificationEvents = [NSMutableArray new];
+        }
+        [self.pendingNotificationEvents addObject:resultDict];
+        return;
+    }
+
     dispatch_async(dispatch_get_main_queue(), ^{
         [self.channel invokeMethod:@"CleverPush#handleNotificationReceived" arguments:resultDict];
     });
+}
+
+- (void)deliverPendingNotificationEvents {
+    if (!self.pendingNotificationEvents || self.pendingNotificationEvents.count == 0) return;
+    NSArray *events = [self.pendingNotificationEvents copy];
+    [self.pendingNotificationEvents removeAllObjects];
+    for (NSDictionary *dict in events) {
+        [self.channel invokeMethod:@"CleverPush#handleNotificationReceived" arguments:dict];
+    }
+}
+
+- (BOOL)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
+    if ([CleverPush channelId]) {
+        BOOL startedBackgroundJob = [CleverPush handleSilentNotificationReceived:application UserInfo:userInfo completionHandler:completionHandler];
+        if (!startedBackgroundJob) {
+            completionHandler(UIBackgroundFetchResultNewData);
+        }
+        return YES;
+    } else {
+        completionHandler(UIBackgroundFetchResultNoData);
+        return NO;
+    }
 }
 
 - (void)handleNotificationOpened:(CPNotificationOpenedResult *)result {

--- a/ios/Classes/CleverPushPlugin.m
+++ b/ios/Classes/CleverPushPlugin.m
@@ -585,7 +585,7 @@
     if ([CleverPush channelId]) {
         BOOL startedBackgroundJob = [CleverPush handleSilentNotificationReceived:application UserInfo:userInfo completionHandler:completionHandler];
         if (!startedBackgroundJob) {
-            completionHandler(UIBackgroundFetchResultNewData);
+            completionHandler(UIBackgroundFetchResultNoData);
         }
         return YES;
     } else {


### PR DESCRIPTION
iOS in-app messages/banners are not displayed with silent push notifications in Flutter.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes iOS Flutter in‑app messages/banners not showing when delivered via silent push. Addresses CP-11278 by handling silent notifications on launch/background and queuing events until Dart is ready.

- **Bug Fixes**
  - Early-initialize `CleverPush` at plugin registration using stored channel ID; persist channel ID on init.
  - Handle silent pushes on cold start and in background via `handleSilentNotificationReceived` with proper fetch completion.
  - Buffer notification-received events before Dart init (`pendingNotificationEvents`) and flush after `dartInitialized`.
  - Minor cleanup: rename `launchOptions` to `appLaunchOptions` and small type fixes.

<sup>Written for commit 4eba7a7d0e26cdd2686a4e3768b65188b048bebe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

