### PR TITLE
feature/cp-11359-flutter-implement-method-for-marking-subscription-as-test

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -38,7 +38,7 @@ android {
 }
 
 dependencies {
-    api 'com.cleverpush:cleverpush:1.35.25'
+    api 'com.cleverpush:cleverpush:1.35.27'
 }
 
 class DefaultManifestPlaceHolders {

--- a/android/src/main/java/com/cleverpush/flutter/CleverPushPlugin.java
+++ b/android/src/main/java/com/cleverpush/flutter/CleverPushPlugin.java
@@ -210,6 +210,8 @@ public class CleverPushPlugin extends FlutterMessengerResponder implements Metho
             replySuccess(result, null);
         } else if (call.method.contentEquals("CleverPush#removeAllNotifications")) {
           this.removeAllNotifications(call, result);
+        } else if (call.method.contentEquals("CleverPush#markSubscriptionAsTest")) {
+            this.markSubscriptionAsTest(call, result);
         } else {
             replyNotImplemented(result);
         }
@@ -823,5 +825,19 @@ public class CleverPushPlugin extends FlutterMessengerResponder implements Metho
     private void removeAllNotifications(MethodCall call, final Result result) {
         CleverPush.getInstance(context).removeAllNotifications();
         replySuccess(result, null);
+    }
+
+    private void markSubscriptionAsTest(MethodCall call, final Result result) {
+        CleverPush.getInstance(context).markSubscriptionAsTest(new CompletionFailureListener() {
+            @Override
+            public void onComplete() {
+                replySuccess(result, null);
+            }
+
+            @Override
+            public void onFailure(Exception exception) {
+                replySuccess(result, null);
+            }
+        });
     }
 }

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,10 +1,10 @@
 PODS:
-  - CleverPush (1.34.41):
-    - CleverPush/CleverPush (= 1.34.41)
-  - CleverPush/CleverPush (1.34.41)
-  - CleverPush/CleverPushExtension (1.34.41)
+  - CleverPush (1.34.43):
+    - CleverPush/CleverPush (= 1.34.43)
+  - CleverPush/CleverPush (1.34.43)
+  - CleverPush/CleverPushExtension (1.34.43)
   - cleverpush_flutter (1.24.33):
-    - CleverPush (= 1.34.41)
+    - CleverPush (= 1.34.43)
     - Flutter
   - Flutter (1.0.0)
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -305,6 +305,10 @@ class _MyAppState extends State<MyApp> {
     });
   }
 
+  void _handleMarkSubscriptionAsTest() {
+    CleverPush.shared.markSubscriptionAsTest();
+  }
+
   @override
   Widget build(BuildContext context) {
     return new MaterialApp(
@@ -352,6 +356,10 @@ class _MyAppState extends State<MyApp> {
                     new TableRow(children: [
                       new CleverPushButton(
                           "Is Subscribed?", _handleIsSubscribed, true)
+                    ]),
+                    new TableRow(children: [
+                      new CleverPushButton(
+                          "Mark Subscription As Test", _handleMarkSubscriptionAsTest, true)
                     ]),
                     new TableRow(children: [
                       new CleverPushButton(

--- a/ios/Classes/CleverPushPlugin.m
+++ b/ios/Classes/CleverPushPlugin.m
@@ -175,6 +175,8 @@
         [self setHandleUrlFromSceneDelegate:call withResult:result];
     else if ([@"CleverPush#removeAllNotifications" isEqualToString:call.method])
         [self removeAllNotifications:call withResult:result];
+    else if ([@"CleverPush#markSubscriptionAsTest" isEqualToString:call.method])
+        [self markSubscriptionAsTest:call withResult:result];
     else
         result(FlutterMethodNotImplemented);
 }
@@ -703,6 +705,14 @@
 - (void)removeAllNotifications:(FlutterMethodCall *)call withResult:(FlutterResult)result {
     [CleverPush removeAllNotifications];
     result(nil);
+}
+
+- (void)markSubscriptionAsTest:(FlutterMethodCall *)call withResult:(FlutterResult)result {
+    [CleverPush markSubscriptionAsTestOnSuccess:^(NSDictionary * _Nullable res) {
+        result(nil);
+    } onFailure:^(NSError * _Nullable error) {
+        result(nil);
+    }];
 }
 
 - (NSDictionary *)dictionaryWithPropertiesOfObject:(id)obj {

--- a/ios/cleverpush_flutter.podspec
+++ b/ios/cleverpush_flutter.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'CleverPush', '1.34.41'
+  s.dependency 'CleverPush', '1.34.43'
   s.static_framework = true
   s.ios.deployment_target = '8.0'
 end

--- a/lib/cleverpush_flutter.dart
+++ b/lib/cleverpush_flutter.dart
@@ -329,6 +329,10 @@ class CleverPush {
     );
   }
 
+  Future<dynamic> markSubscriptionAsTest() async {
+    return await _channel.invokeMethod("CleverPush#markSubscriptionAsTest");
+  }
+
   Future<Null> _handleMethod(MethodCall call) async {
     try {
       if (


### PR DESCRIPTION
Added method `markSubscriptionAsTest` to mark subscription as test

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `CleverPush.markSubscriptionAsTest()` to flag the current subscription as a test on Android and iOS. Implements Linear CP-11359.

- **New Features**
  - New Dart API: `CleverPush.markSubscriptionAsTest()`, wired to native handlers on Android and iOS.

- **Dependencies**
  - Android: bumps `com.cleverpush:cleverpush` to `1.35.27`.
  - iOS: bumps `CleverPush` pod to `1.34.43`.

<sup>Written for commit e9643b29c2065c825c7948e9c8bc157b5af3ccd1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

