### PR TITLE
hotfix/cp-11157-init-future-never-completes-when-initialization-fails

### DIFF
--- a/android/src/main/java/com/cleverpush/flutter/CleverPushPlugin.java
+++ b/android/src/main/java/com/cleverpush/flutter/CleverPushPlugin.java
@@ -249,10 +249,14 @@ public class CleverPushPlugin extends FlutterMessengerResponder implements Metho
             }
         };
 
+        final boolean[] replied = {false};
         cleverPush.init(channelId, receivedListener, this, this, autoRegister, new InitializeListener() {
             @Override
             public void onInitialized() {
-                replySuccess(reply, null);
+                if (!replied[0]) {
+                    replySuccess(reply, null);
+                    replied[0] = true;
+                }
             }
 
             @Override
@@ -267,9 +271,16 @@ public class CleverPushPlugin extends FlutterMessengerResponder implements Metho
             @Override
             public void onInitializationFailure(Throwable throwable) {
                 InitializeListener.super.onInitializationFailure(throwable);
+                if (!replied[0]) {
+                    replySuccess(reply, null);
+                    replied[0] = true;
+                }
+                String failureMessage = (throwable != null && throwable.getMessage() != null)
+                        ? throwable.getMessage()
+                        : "Initialization failed with unknown error.";
                 HashMap<String, Object> hash = new HashMap<>();
                 hash.put("success", false);
-                hash.put("failureMessage", throwable.getMessage() != null ? throwable.getMessage() : "Initialization failed with unknown error.");
+                hash.put("failureMessage", failureMessage);
                 invokeMethodOnUiThread("CleverPush#handleInitialized", hash);
             }
         });


### PR DESCRIPTION
Prevent multiple replies and ensure init() Future always resolves

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guarantees the Flutter `init()` Future always resolves on CleverPush initialization failure and prevents multiple MethodChannel replies. Addresses Linear CP-11157 to stop hangs and “already replied” errors.

- **Bug Fixes**
  - Add `replied` guard to call `replySuccess` exactly once across success and failure callbacks in `CleverPushPlugin`.
  - On failure, still resolve the method call and emit `CleverPush#handleInitialized` with `success: false` and a null-safe `failureMessage`.

<sup>Written for commit c3f8a568be642b2d0b153df42cab04bcdebb5f3f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

