### PR TITLE
feature/cp-11047-add-uiscene-life-cycle-support

### DIFF
--- a/ios/Classes/CPStoryViewFlutter.m
+++ b/ios/Classes/CPStoryViewFlutter.m
@@ -308,7 +308,21 @@
 - (void)updateDarkModeState {
     BOOL isDarkMode = NO;
     if (@available(iOS 13.0, *)) {
-        UIWindow *window = [UIApplication sharedApplication].windows.firstObject;
+        UIWindow *window = nil;
+
+        for (UIScene *scene in [UIApplication sharedApplication].connectedScenes) {
+            if (![scene isKindOfClass:[UIWindowScene class]]) continue;
+            UIWindowScene *windowScene = (UIWindowScene *)scene;
+            if (windowScene.activationState == UISceneActivationStateForegroundActive) {
+                window = windowScene.windows.firstObject;
+                break;
+            }
+        }
+
+        if (!window) {
+            window = [UIApplication sharedApplication].windows.firstObject;
+        }
+
         if (window) {
             isDarkMode = (window.traitCollection.userInterfaceStyle == UIUserInterfaceStyleDark);
         }

--- a/ios/Classes/CleverPushPlugin.h
+++ b/ios/Classes/CleverPushPlugin.h
@@ -1,9 +1,14 @@
 #import <Flutter/Flutter.h>
 #import <CleverPush/CleverPush.h>
 
+#ifdef FlutterSceneLifeCycleDelegate
+@interface CleverPushPlugin : NSObject<FlutterPlugin, FlutterSceneLifeCycleDelegate>
+#else
 @interface CleverPushPlugin : NSObject<FlutterPlugin>
+#endif
 
 @property (strong, nonatomic) FlutterMethodChannel *channel;
+@property (weak, nonatomic) NSObject<FlutterPluginRegistrar> *registrar;
 
 + (instancetype)sharedInstance;
 

--- a/ios/Classes/CleverPushPlugin.h
+++ b/ios/Classes/CleverPushPlugin.h
@@ -1,7 +1,8 @@
 #import <Flutter/Flutter.h>
 #import <CleverPush/CleverPush.h>
 
-#ifdef FlutterSceneLifeCycleDelegate
+#if __has_include(<Flutter/FlutterSceneLifeCycle.h>)
+#import <Flutter/FlutterSceneLifeCycle.h>
 @interface CleverPushPlugin : NSObject<FlutterPlugin, FlutterSceneLifeCycleDelegate>
 #else
 @interface CleverPushPlugin : NSObject<FlutterPlugin>

--- a/ios/Classes/CleverPushPlugin.m
+++ b/ios/Classes/CleverPushPlugin.m
@@ -28,6 +28,7 @@
 
 + (void)registerWithRegistrar:(NSObject <FlutterPluginRegistrar> *)registrar {
     CleverPushPlugin.sharedInstance.hasNotificationOpenedHandler = NO;
+    CleverPushPlugin.sharedInstance.registrar = registrar;
 
     CleverPushPlugin.sharedInstance.channel = [FlutterMethodChannel
                                                methodChannelWithName:@"CleverPush"
@@ -56,6 +57,14 @@
             }
         } handleSubscribed:nil autoRegister:NO handleInitialized:nil];
     }
+
+    if ([registrar respondsToSelector:@selector(addSceneDelegate:)]) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wundeclared-selector"
+        [registrar performSelector:@selector(addSceneDelegate:)
+                        withObject:CleverPushPlugin.sharedInstance];
+#pragma clang diagnostic pop
+    }
 }
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
@@ -65,6 +74,52 @@
         [CleverPush handleSilentNotificationReceived:application UserInfo:remoteNotif completionHandler:nil];
     }
     return YES;
+}
+
+- (BOOL)scene:(UIScene *)scene
+    willConnectToSession:(UISceneSession *)session
+                 options:(UISceneConnectionOptions *)connectionOptions API_AVAILABLE(ios(13.0)) {
+    NSDictionary *launchOptions = [self connectionOptionsToLaunchOptions:connectionOptions];
+    if (launchOptions) {
+        CleverPushPlugin.sharedInstance.appLaunchOptions = launchOptions;
+    }
+    return YES;
+}
+
+- (NSDictionary *)connectionOptionsToLaunchOptions:(UISceneConnectionOptions *)connectionOptions API_AVAILABLE(ios(13.0)) {
+    NSMutableDictionary *launchOptions = [NSMutableDictionary dictionary];
+
+    if (connectionOptions.notificationResponse) {
+        NSDictionary *userInfo = connectionOptions.notificationResponse.notification.request.content.userInfo;
+        if (userInfo) {
+            launchOptions[UIApplicationLaunchOptionsRemoteNotificationKey] = userInfo;
+        }
+    }
+
+    for (UIOpenURLContext *urlContext in connectionOptions.URLContexts) {
+        if (urlContext.URL) {
+            launchOptions[UIApplicationLaunchOptionsURLKey] = urlContext.URL;
+            if (urlContext.options.sourceApplication) {
+                launchOptions[UIApplicationLaunchOptionsSourceApplicationKey] =
+                    urlContext.options.sourceApplication;
+            }
+        }
+        break;
+    }
+
+    if (connectionOptions.shortcutItem) {
+        launchOptions[UIApplicationLaunchOptionsShortcutItemKey] = connectionOptions.shortcutItem;
+    }
+
+    NSUserActivity *userActivity = connectionOptions.userActivities.anyObject;
+    if (userActivity) {
+        launchOptions[UIApplicationLaunchOptionsUserActivityDictionaryKey] = @{
+            UIApplicationLaunchOptionsUserActivityTypeKey: userActivity.activityType,
+            @"UIApplicationLaunchOptionsUserActivityKey": userActivity
+        };
+    }
+
+    return launchOptions.count > 0 ? [NSDictionary dictionaryWithDictionary:launchOptions] : nil;
 }
 
 - (void)handleMethodCall:(FlutterMethodCall *)call result:(FlutterResult)result {
@@ -275,15 +330,27 @@
 }
 
 - (UIWindow *)keyWindow {
-    UIWindow *foundWindow = nil;
-    NSArray *windows = [[UIApplication sharedApplication] windows];
-    for (UIWindow *window in windows) {
-        if (window.isKeyWindow) {
-            foundWindow = window;
-            break;
+    if (@available(iOS 15.0, *)) {
+        UIWindow *keyWindow = self.registrar.viewController.view.window.windowScene.keyWindow;
+        if (keyWindow) return keyWindow;
+    }
+
+    if (@available(iOS 13.0, *)) {
+        for (UIScene *scene in [UIApplication sharedApplication].connectedScenes) {
+            if (![scene isKindOfClass:[UIWindowScene class]]) continue;
+            UIWindowScene *windowScene = (UIWindowScene *)scene;
+            if (windowScene.activationState == UISceneActivationStateForegroundActive) {
+                for (UIWindow *window in windowScene.windows) {
+                    if (window.isKeyWindow) return window;
+                }
+            }
         }
     }
-    return foundWindow;
+
+    for (UIWindow *window in [UIApplication sharedApplication].windows) {
+        if (window.isKeyWindow) return window;
+    }
+    return nil;
 }
 
 - (void)showTopicsDialog:(FlutterMethodCall *)call withResult:(FlutterResult)result {


### PR DESCRIPTION
Added UIScene Life Cycle Support for iOS in Flutter.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds UIScene lifecycle support to the iOS Flutter plugin to handle scene-based launches on iOS 13+. Implements CP-11047 and fixes key window resolution and dark mode detection in multi‑scene apps.

- **New Features**
  - `CleverPushPlugin` adopts `FlutterSceneLifeCycleDelegate` (when available) and registers via `addSceneDelegate:`.
  - Adds `scene:willConnectToSession:options:` and converts `UISceneConnectionOptions` to `launchOptions` (notifications, URLs, shortcuts, user activities) for initialization.
  - Improves key window lookup on iOS 13+ and iOS 15+ using the registrar’s view controller window, the foreground `UIWindowScene`, then app windows.
  - Updates `CPStoryViewFlutter` dark mode detection to read the foreground-active scene’s window, with fallback.

<sup>Written for commit 9e1f9f265f742b9838b60f23b98fc1e392b382c5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

